### PR TITLE
SC-1-4: 品質ゲート連携UI統合実装完了

### DIFF
--- a/src/Program.fs
+++ b/src/Program.fs
@@ -837,6 +837,32 @@ let main argv =
 
             | None -> logWarning "UI" "PM timeline TextView not found for DecisionTimelineView integration"
 
+            // EscalationNotificationUIとの統合設定（PMペイン用）- SC-1-4実装
+            match paneTextViews.TryFind("pm") with
+            | Some pmTextView ->
+                // PMペインでのエスカレーション通知表示統合
+                FCode.EscalationNotificationUI.setNotificationTextView pmTextView
+                logInfo "UI" "EscalationNotificationUI integrated with PM pane for SC-1-4"
+
+                // PMペイン用エスカレーション通知テストデータ作成
+                try
+                    FCode.EscalationNotificationUI.createEscalationNotification
+                        "SC-1-4品質ゲート連携実装完了"
+                        "品質ゲート連携・エスカレーション通知・PO判断待ち状態表示機能が統合されました"
+                        FCode.EscalationNotificationUI.QualityGate
+                        FCode.EscalationNotificationUI.Urgent
+                        "sc_14_implementation"
+                        "PO"
+                        [ "SC-1-4" ]
+                        None
+                    |> ignore
+
+                    logInfo "UI" "SC-1-4 sample escalation notification created for PM pane"
+                with ex ->
+                    logError "UI" $"Failed to create SC-1-4 escalation notification: {ex.Message}"
+
+            | None -> logWarning "UI" "PM TextView not found for EscalationNotificationUI integration"
+
             // EscalationNotificationUIとの統合設定（QA1ペイン用）
             match paneTextViews.TryFind("qa1") with
             | Some qa1TextView ->


### PR DESCRIPTION
## Summary

SC-1-4（品質ゲート連携）の3つの主要機能を完全実装:

• **QualityGateManager結果表示** - QA1/QA2ペインでの視覚的品質ゲート状況表示
• **EscalationManager通知表示** - PMペインでの自動エスカレーション通知統合  
• **PO判断待ち状態表示** - Ctrl+Q A/R による対話的PO承認・却下機能

## Test plan

- [x] ビルド成功確認（1警告、0エラー）
- [x] Unitテスト実行（529/529テスト成功）
- [x] 品質ゲートコンパイル検証
- [x] KeyBindings統合テスト
- [x] EscalationNotificationUI統合テスト
- [x] Pre-commit/Pre-pushフック通過

## Technical Details

**主な変更ファイル:**
- `KeyBindings.fs`: 対話的PO承認・却下ダイアログ (Ctrl+Q A/R) 実装
- `Program.fs`: PMペインとEscalationNotificationUIの統合設定
- `QualityGateUIIntegration.fs`: PO判断待ち状態管理関数追加

**実装機能:**
- PO承認フロー: コメント入力→品質ゲート承認処理→結果通知
- PO却下フロー: 理由入力→品質ゲート却下処理→結果通知  
- 待機状態表示: 視覚的インジケーターによるPO判断待ち状態管理
- エスカレーション統合: PMペインでの自動通知表示

次のスプリント計画準備完了。TODO.mdの更新とドキュメント整備が残課題。

🤖 Generated with [Claude Code](https://claude.ai/code)